### PR TITLE
refactor: switch from initializeArray to Array.fill

### DIFF
--- a/lib/gpx.js
+++ b/lib/gpx.js
@@ -1,12 +1,5 @@
 import { nodeVal } from "./shared";
 
-function initializeArray(arr, size) {
-  for (let h = 0; h < size; h++) {
-    arr.push(null);
-  }
-  return arr;
-}
-
 function getLineStyle(extensions) {
   const style = {};
   if (extensions) {
@@ -104,22 +97,22 @@ function getPoints(node, pointname) {
   const pts = node.getElementsByTagName(pointname);
   const line = [];
   const times = [];
-  const heartRates = [];
   const l = pts.length;
+  let heartRates = undefined;
   if (l < 2) return {}; // Invalid line in GeoJSON
   for (let i = 0; i < l; i++) {
     const c = coordPair(pts[i]);
     line.push(c.coordinates);
     if (c.time) times.push(c.time);
-    if (c.heartRate || heartRates.length) {
-      if (!heartRates.length) initializeArray(heartRates, i);
+    if (c.heartRate || heartRates) {
+      if (!heartRates) heartRates = Array(i).fill(null);
       heartRates.push(c.heartRate || null);
     }
   }
   return {
     line: line,
     times: times,
-    heartRates: heartRates
+    heartRates: heartRates || []
   };
 }
 function getTrack(node) {
@@ -136,13 +129,13 @@ function getTrack(node) {
       if (heartRates.length || (line.heartRates && line.heartRates.length)) {
         if (!heartRates.length) {
           for (let s = 0; s < i; s++) {
-            heartRates.push(initializeArray([], track[s].length));
+            heartRates.push(Array(track[s].length).fill(null));
           }
         }
         if (line.heartRates && line.heartRates.length) {
           heartRates.push(line.heartRates);
         } else {
-          heartRates.push(initializeArray([], line.line.length || 0));
+          heartRates.push(Array(line.line.length || 0).fill(null));
         }
       }
     }


### PR DESCRIPTION
Fixes #10

BREAKING CHANGE: this may modify browser support if you’re using
an old browser. See the MDN page for full details:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill