### PR TITLE
feat: Output features with null geometries instead of omitting those features

### DIFF
--- a/lib/kml.js
+++ b/lib/kml.js
@@ -159,7 +159,6 @@ function getPlacemark(root, styleIndex, styleMapIndex, styleByHash) {
   let polyStyle = get1(root, "PolyStyle");
   const visibility = get1(root, "visibility");
 
-  if (!geomsAndTimes.geoms.length) return;
   if (name) properties.name = name;
   if (address) properties.address = address;
   if (styleUrl) {
@@ -248,7 +247,9 @@ function getPlacemark(root, styleIndex, styleMapIndex, styleByHash) {
   const feature = {
     type: "Feature",
     geometry:
-      geomsAndTimes.geoms.length === 1
+      geomsAndTimes.geoms.length === 0
+        ? null
+        : geomsAndTimes.geoms.length === 1
         ? geomsAndTimes.geoms[0]
         : {
             type: "GeometryCollection",

--- a/tap-snapshots/test-index.test.js-TAP.test.js
+++ b/tap-snapshots/test-index.test.js-TAP.test.js
@@ -11397,7 +11397,20 @@ Object {
 
 exports[`test/index.test.js TAP toGeoJSON > nogeomplacemark.kml 1`] = `
 Object {
-  "features": Array [],
+  "features": Array [
+    Object {
+      "geometry": null,
+      "properties": Object {
+        "fill": "ff0011",
+        "fill-opacity": 1,
+        "name": "With all inline styles",
+        "stroke": "ff0",
+        "stroke-opacity": 0,
+        "stroke-width": 3,
+      },
+      "type": "Feature",
+    },
+  ],
   "type": "FeatureCollection",
 }
 `


### PR DESCRIPTION
BREAKING CHANGE: Previously, togeojson would ignore Placemarks that did not have
associated geometry. [Per the GeoJSON
specification](https://tools.ietf.org/html/rfc7946#section-3.2),
Feature objects can have null geometries. After this change, togeojson
will output features with null geometries as the translation of KML
Placemarks with no geometry, instead of ommitting those items entirely.

Fixes #24