### PR TITLE
Rename heartRates coordinate property to heart

### DIFF
--- a/lib/gpx.js
+++ b/lib/gpx.js
@@ -69,7 +69,7 @@ function coordPair(x) {
   ];
   const ele = get1(x, "ele");
   // handle namespaced attribute in browser
-  const heartRate = get1(x, "gpxtpx:hr") || get1(x, "hr");
+  const heart = get1(x, "gpxtpx:hr") || get1(x, "hr");
   const time = get1(x, "time");
   let e;
   if (ele) {
@@ -84,8 +84,8 @@ function coordPair(x) {
     extendedValues: [],
   };
 
-  if (heartRate) {
-    result.extendedValues.push(["heartRate", parseFloat(nodeVal(heartRate))]);
+  if (heart) {
+    result.extendedValues.push(["heart", parseFloat(nodeVal(heart))]);
   }
 
   const extensions = get1(x, "extensions");
@@ -129,7 +129,7 @@ function getPoints(node, pointname) {
     if (c.time) times.push(c.time);
     for (let j = 0; j < c.extendedValues.length; j++) {
       const [name, val] = c.extendedValues[j];
-      const plural = name + "s";
+      const plural = name === "heart" ? name : name + "s";
       if (!extendedValues[plural]) {
         extendedValues[plural] = Array(pts.length).fill(null);
       }
@@ -179,7 +179,7 @@ function getTrack(node) {
     track.push(line.line);
     for (const [name, val] of Object.entries(line.extendedValues)) {
       let props = properties;
-      if (name === "heartRates") {
+      if (name === "heart") {
         if (!properties.coordinateProperties) {
           properties.coordinateProperties = {};
         }

--- a/lib/tcx.js
+++ b/lib/tcx.js
@@ -146,7 +146,7 @@ function getLap(node) {
         : {},
       heartRates.length
         ? {
-            heartRates: track.length === 1 ? heartRates[0] : heartRates,
+            heart: track.length === 1 ? heartRates[0] : heartRates,
           }
         : {}
     );

--- a/tap-snapshots/test-index.test.js-TAP.test.js
+++ b/tap-snapshots/test-index.test.js-TAP.test.js
@@ -13245,7 +13245,7 @@ Object {
       "properties": Object {
         "_gpxType": "trk",
         "coordinateProperties": Object {
-          "heartRates": Array [
+          "heart": Array [
             Array [
               null,
               null,
@@ -17971,7 +17971,7 @@ Object {
       "properties": Object {
         "_gpxType": "trk",
         "coordinateProperties": Object {
-          "heartRates": Array [
+          "heart": Array [
             130,
             134,
             139,
@@ -18620,7 +18620,7 @@ Object {
       "properties": Object {
         "_gpxType": "trk",
         "coordinateProperties": Object {
-          "heartRates": Array [
+          "heart": Array [
             111,
             111,
             111,
@@ -23356,7 +23356,7 @@ Object {
       },
       "properties": Object {
         "coordinateProperties": Object {
-          "heartRates": Array [
+          "heart": Array [
             121,
             122,
             123,


### PR DESCRIPTION
@tmcw I renamed the property from `heartRates` to `heart` as per @jsejcksn's proposal: https://github.com/tmcw/togeojson/issues/29#issuecomment-811733417.

Would be cool if you could have a look when you get a chance. Thanks!